### PR TITLE
checking if options.date is truthy

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function stringToSign (options) {
     [ options.verb
     , options.md5
     , options.contentType
-    , options.date.toUTCString()
+    , options.date ? options.date.toUTCString() : ''
     , headers + options.resource
     ]
   return r.join('\n')


### PR DESCRIPTION
I'm using client which doesn't send the Date header.
Because of this I'm getting the following error:
`TypeError: Object  has no method 'toUTCString'
    at stringToSign (/home/developer/s3proxy/node_modules/aws-sign/index.js:121:20)`

My patch fixes this issue if there is no date given.
